### PR TITLE
add setuptools-based way to create binary wheels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "secp256k1"]
+	path = libsecp256k1
+	url = https://github.com/bitcoin-core/secp256k1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+# note: files listed in this file:
+#       - will be added to the sdist
+#       - but won't be added to the wheel (unless by other means)
+
+graft libsecp256k1/
+prune libsecp256k1/ci/
+prune libsecp256k1/.github/
+global-exclude .*

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Unlike Coincurve, it uses ctypes, and has no dependency.
 
 To build sdist for PyPI:
 ```
-$ python3 -m build --sdist .
+$ ./contrib/release.sh
 ```

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+PROJECT_ROOT="$(dirname "$(readlink -e "$0")")/.."
+CONTRIB="$PROJECT_ROOT/contrib"
+
+cd "$PROJECT_ROOT"
+
+
+git_status=$(git status --porcelain)
+if [ ! -z "$git_status" ]; then
+    echo "$git_status"
+    echo "git repo not clean, aborting"
+    exit 1
+fi
+
+# clean git submodules
+# note: e.g. if you build a wheel, that side-effects the libsecp dir,
+#       and build artifacts would leak into a subsequent sdist build.
+git submodule update --init
+pushd libsecp256k1/
+git clean -ffxd
+git reset --hard
+popd
+
+
+cd "$PROJECT_ROOT"
+python3 -m build --sdist .
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = ["setuptools"]
+# ^ note: we also require wheel, but apparently that does not have to be specified.
+#         see https://github.com/python/importlib_metadata/commit/aae281a9ff6c9a1fa9daad82c79457e8770a1c7e
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "electrum-ecc"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -103,10 +103,9 @@ class bdist_wheel(_bdist_wheel):
 
         build_temp_libs = os.path.join(build_dir, "lib")
         for fname in os.listdir(build_temp_libs):
-            if (
-                    fname.endswith(".so") or fname.endswith(".dll") or fname.endswith(".dylib")
-                    or ".so." in fname  # FIXME symlink duplication
-            ):
+            # note: we skip the versioned .so files (e.g. "*.so.2.2.0"), as wheels don't
+            #       support symlinks and we would end up with ~3 copies of the same file
+            if fname.endswith(".so") or fname.endswith(".dll") or fname.endswith(".dylib"):
                 srcpath = os.path.join(build_temp_libs, fname)
                 _logger.info(f"copying file {srcpath!r} to {target_dir=}")
                 shutil.copy2(srcpath, target_dir)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,123 @@
+# based on https://github.com/ludbb/secp256k1-py/blob/f5e455227bf1e833128adf80de8ee0ebcebf218c/setup.py
+
+import errno
+import logging
+import os
+import os.path
+import platform
+import shutil
+import subprocess
+
+from setuptools import setup
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+from wheel.bdist_wheel import safer_name, get_platform
+
+
+_logger = logging.getLogger("electrum_ecc")
+MAKE = 'gmake' if platform.system() in ['FreeBSD', 'OpenBSD'] else 'make'
+
+
+def absolute(*paths):
+    op = os.path
+    return op.realpath(op.abspath(op.join(op.dirname(__file__), *paths)))
+
+
+def compile_secp(build_dir: str) -> None:
+    if not os.path.exists(absolute('libsecp256k1')):
+        raise Exception("missing git submodule secp256k1")
+
+    if not os.path.exists(absolute('libsecp256k1/configure')):
+        # configure script hasn't been generated yet
+        autogen = absolute('libsecp256k1/autogen.sh')
+        os.chmod(absolute(autogen), 0o755)
+        subprocess.check_call([autogen], cwd=absolute('libsecp256k1'))
+
+    for filename in [
+        'libsecp256k1/configure',
+        'libsecp256k1/build-aux/compile',
+        'libsecp256k1/build-aux/config.guess',
+        'libsecp256k1/build-aux/config.sub',
+        'libsecp256k1/build-aux/depcomp',
+        'libsecp256k1/build-aux/install-sh',
+        'libsecp256k1/build-aux/missing',
+        'libsecp256k1/build-aux/test-driver',
+    ]:
+        try:
+            os.chmod(absolute(filename), 0o755)
+        except OSError as e:
+            # some of these files might not exist depending on autoconf version
+            if e.errno != errno.ENOENT:
+                # If the error isn't 'No such file or directory' something
+                # else is wrong and we want to know about it
+                raise
+
+    cmd = [
+        absolute('libsecp256k1/configure'),
+        '--enable-shared',
+        '--disable-static',
+        '--disable-dependency-tracking',
+        '--with-pic',
+        '--prefix',
+        os.path.abspath(build_dir),
+        '--enable-module-recovery',
+        '--enable-module-extrakeys',
+        '--enable-module-schnorrsig',
+        '--enable-experimental',
+        '--enable-module-ecdh',
+        '--enable-benchmark=no',
+        '--enable-tests=no',
+        '--enable-openssl-tests=no',
+        '--enable-exhaustive-tests=no',
+    ]
+
+    _logger.info('Running configure: {}'.format(' '.join(cmd)))
+    subprocess.check_call(cmd, cwd=build_dir)
+
+    subprocess.check_call([MAKE], cwd=build_dir)
+    subprocess.check_call([MAKE, 'install'], cwd=build_dir)
+
+
+class bdist_wheel(_bdist_wheel):
+
+    def finalize_options(self):
+        # Inject the platform name, e.g. "linux_x86_64".
+        # This will result in the final build artifact being named e.g.
+        #   electrum_ecc-0.0.2-py3-none-linux_x86_64.whl
+        self.plat_name = get_platform(self.bdist_dir)
+        # note: we don't set the python "impl tag" or the "abi tag", as the C lib we build
+        #       does not depend on them (it is not a "C extension" as we don't static link cpython).
+        _bdist_wheel.finalize_options(self)
+
+    def _build_and_copy_secp_lib(self):
+        _build_cmd = self.get_finalized_command('build')
+        build_dir = os.path.join(_build_cmd.build_base, "temp_libsecp")
+        target_dir = os.path.join(self.bdist_dir, safer_name(self.distribution.get_name()))
+        for dir_ in (build_dir, target_dir):
+            try:
+                os.makedirs(dir_)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+
+        compile_secp(build_dir)
+
+        build_temp_libs = os.path.join(build_dir, "lib")
+        for fname in os.listdir(build_temp_libs):
+            if (
+                    fname.endswith(".so") or fname.endswith(".dll") or fname.endswith(".dylib")
+                    or ".so." in fname  # FIXME symlink duplication
+            ):
+                srcpath = os.path.join(build_temp_libs, fname)
+                _logger.info(f"copying file {srcpath!r} to {target_dir=}")
+                shutil.copy2(srcpath, target_dir)
+
+    def run(self):
+        self._build_and_copy_secp_lib()
+        _bdist_wheel.run(self)
+
+
+setup(
+    cmdclass={
+        'bdist_wheel': bdist_wheel,
+    },
+)

--- a/src/electrum_ecc/ecc_fast.py
+++ b/src/electrum_ecc/ecc_fast.py
@@ -53,24 +53,35 @@ def load_library():
     # note: for a mapping between bitcoin-core/secp256k1 git tags and .so.V libtool version numbers,
     #       see https://github.com/bitcoin-core/secp256k1/pull/1055#issuecomment-1227505189
     tested_libversions = [2, 1, 0, ]  # try latest version first
-    libnames = []
+    libnames_local = []
+    libnames_anywhere = []
     if sys.platform == 'darwin':
         for v in tested_libversions:
-            libnames.append(f"libsecp256k1.{v}.dylib")
+            libname = f"libsecp256k1.{v}.dylib"
+            libnames_local.append(libname)
+            libnames_anywhere.append(libname)
     elif sys.platform in ('windows', 'win32'):
         for v in tested_libversions:
-            libnames.append(f"libsecp256k1-{v}.dll")
+            libname = f"libsecp256k1-{v}.dll"
+            libnames_local.append(libname)
+            libnames_anywhere.append(libname)
     elif 'ANDROID_DATA' in os.environ:
-        libnames = ['libsecp256k1.so', ]  # don't care about version number. we built w/e is available.
+        # don't care about version number. we built w/e is available.
+        libname = "libsecp256k1.so"
+        libnames_local.append(libname)
+        libnames_anywhere.append(libname)
     else:  # desktop Linux and similar
         for v in tested_libversions:
-            libnames.append(f"libsecp256k1.so.{v}")
+            libname = f"libsecp256k1.so.{v}"
+            libnames_local.append(libname)
+            libnames_anywhere.append(libname)
+        libnames_local.append("libsecp256k1.so")
         # maybe we could fall back to trying "any" version? maybe guarded with an env var?
-        #libnames.append(f"libsecp256k1.so")
+        #libnames_anywhere.append(f"libsecp256k1.so")
     library_paths = []
-    for libname in libnames:  # try local files in repo dir first
+    for libname in libnames_local:  # try local files in repo dir first (for security, but also compat)
         library_paths.append(os.path.join(os.path.dirname(__file__), libname))
-    for libname in libnames:
+    for libname in libnames_anywhere:
         library_paths.append(libname)
 
     exceptions = []


### PR DESCRIPTION
See individual commits.

In short, this adds a way to build binary wheels using setuptools.
(Note that I still don't want us to release binary wheels on PyPI, but modern "pip install" works by either grabbing a wheel and just unpacking it, or grabbing an sdist and building a wheel from it and unpacking that. It is simply that workflow I am concerned about here.)

The idea is that 
- we would release just an sdist on PyPI
- Electrum would depend on `electrum_ecc`
- If a user `pip install`s an Electrum tar.gz or a git clone, that would pull in `electrum_ecc` (being a dependency), and it would try to compile libsecp as part of that build. Setting the `ELECTRUM_ECC_DONT_COMPILE=1` env var is a way to opt-out of the compilation -- at that point it becomes the user's responsibility to obtain libsecp, e.g. via `sudo apt install libsecp256k1-1`.

Note that the sdist bundles the libsecp sources (but the wheel does not, instead that bundles the .so/.dll). This is different from what e.g. coincurve does, which downloads it at build-time via http.