### PR TITLE
bump secp v0.5.1->v0.6.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ unittests_task:
     - python3 --version
     - python3 -c "import electrum_ecc; print(f'{electrum_ecc.__version__=}'); print(electrum_ecc.ecc_fast.version_info())"
   script:
-    - pytest --cov=electrum_ecc
+    - pytest tests --cov=electrum_ecc
 
 
 # Test if the ABI version of current "libsecp256k1" git submodule is listed in ecc_fast.KNOWN_COMPATIBLE_ABI_VERSIONS

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ python3 -m unittest discover -s tests -t .
 ```
 Or
 ```
-$ pytest -v
+$ pytest tests -v
 ```
 
 

--- a/src/electrum_ecc/ecc_fast.py
+++ b/src/electrum_ecc/ecc_fast.py
@@ -44,7 +44,7 @@ class LibModuleMissing(Exception): pass
 #       the new version should be tested and added to this list.
 # note: for a mapping between bitcoin-core/secp256k1 git tags and .so.V libtool version numbers,
 #       see https://github.com/bitcoin-core/secp256k1/pull/1055#issuecomment-1227505189
-KNOWN_COMPATIBLE_ABI_VERSIONS = [2, 1, 0, ]  # try latest version first
+KNOWN_COMPATIBLE_ABI_VERSIONS = [5, 2, 1, 0, ]  # try latest version first
 
 
 def load_library():


### PR DESCRIPTION
notes:
- libsecp256k1 v0.6.0 bumped the ABI version from 2 to 5
- there are now some python scripts in the submodule which were inadvertently being picked up by pytest

closes https://github.com/spesmilo/electrum-ecc/issues/4