### PR TITLE
Add ability to skip compilation using PEP517 config settings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@
 #       - but won't be added to the wheel (unless by other means)
 
 graft libsecp256k1/
+graft _custom_build/
 prune libsecp256k1/ci/
 prune libsecp256k1/.github/
+global-exclude *.pyc
 global-exclude .*

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,27 @@
+import sys
+
+from setuptools.build_meta import *  # noqa: F401, F403
+from setuptools.build_meta import build_wheel
+
+backend_class = build_wheel.__self__.__class__
+
+
+class _CustomBuildMetaBackend(backend_class):
+    def run_setup(self, setup_script="setup.py"):
+        flags = []
+        if self.config_settings and "electrum_ecc.dont_compile" in self.config_settings:
+            flags.append(
+                f"--electrum_ecc.dont_compile={self.config_settings['electrum_ecc.dont_compile']}"
+            )
+        if flags:
+            sys.argv = sys.argv[:1] + ["build_ext"] + flags + sys.argv[1:]
+        return super().run_setup(setup_script)
+
+    def build_wheel(
+        self, wheel_directory, config_settings=None, metadata_directory=None
+    ):
+        self.config_settings = config_settings
+        return super().build_wheel(wheel_directory, config_settings, metadata_directory)
+
+
+build_wheel = _CustomBuildMetaBackend().build_wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 requires = ["setuptools >= 61.0.0"]
 # ^ note: we also require wheel, but apparently that does not have to be specified.
 #         see https://github.com/python/importlib_metadata/commit/aae281a9ff6c9a1fa9daad82c79457e8770a1c7e
-build-backend = "setuptools.build_meta"
+build-backend = "backend"
+backend-path = ["_custom_build"]
 
 [project]
 name = "electrum-ecc"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,15 @@ except ImportError as e1:
 _logger = logging.getLogger("electrum_ecc")
 MAKE = 'gmake' if platform.system() in ['FreeBSD', 'OpenBSD'] else 'make'
 
-ELECTRUM_ECC_DONT_COMPILE = os.getenv("ELECTRUM_ECC_DONT_COMPILE") or ""
+ELECTRUM_ECC_DONT_COMPILE = None
+for arg in sys.argv[:]:
+    if arg.startswith("--electrum_ecc.dont_compile="):
+        value = arg.split("=", 1)[1]
+        sys.argv.remove(arg)
+        ELECTRUM_ECC_DONT_COMPILE = value
+        break
+if ELECTRUM_ECC_DONT_COMPILE is None:
+    ELECTRUM_ECC_DONT_COMPILE = os.getenv("ELECTRUM_ECC_DONT_COMPILE") or ""
 _logger.info(f"Checking env var: {ELECTRUM_ECC_DONT_COMPILE=!r}")
 if ELECTRUM_ECC_DONT_COMPILE == "":  # unset
     IS_COMPILING_LIB = sys.platform != "win32"


### PR DESCRIPTION
Using env vars usually works fine, but when including electrum (so it pulls electrum-ecc) as a dependency, because on PyPI wheels aren't uploaded, it is not convenient to ask users to set this env var each time they install the project
This allows to install the package via `pip install electrum-ecc -C electrum_ecc.dont_compile=true`
Or in my case when I am using uv, I can just write in pyproject.toml:

```
[tool.uv]
config-settings = { "electrum_ecc.dont_compile" = "true" }
```

P.S. While I understand why this package may have wheels not uploaded, why does `electrum-aionostr` have no uploaded wheels if they should be universal like py3-any?