### PR TITLE
pyproject.toml: migrate to newer style "license" declaration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ unittests_task:
     - git submodule init
     - git submodule update
   install_script:
+    - pip freeze --all  # to log pip/setuptools/wheel/etc versions
     - pip install pytest-cov
     # TODO cache building libsecp .so, which is done implicitly in the next step:
     - pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ authors = [
 description = "Pure python ctypes wrapper for libsecp256k1"
 keywords = ["libsecp256k1", "ecc"]
 readme = "README.md"
-license = {'file'="LICENSE.txt"}
+license = "MIT"
+license-files = ["LICENSE.txt"]
 requires-python = ">=3.10"
 dependencies = []
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Migrates from [pep-621](https://peps.python.org/pep-0621/#license) style to [pep-639](https://peps.python.org/pep-0639/) style.

Setuptools was spitting out warnings without this.
(however I imagine this change might be breaking builds with old setuptools...)
```
* Building sdist...
No `packages` or `py_modules` configuration, performing automatic discovery.
`src-layout` detected -- analysing ./src
discovered packages -- ['electrum_ecc']
discovered py_modules -- []
/tmp/build-env-4wv4ofaa/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/tmp/build-env-4wv4ofaa/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/tmp/build-env-4wv4ofaa/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running sdist
running egg_info
```